### PR TITLE
Implement "deploy to heroku" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Do you have a GitHub project that is too big for people to subscribe to all the 
 
 <img width="769" src="https://cloud.githubusercontent.com/assets/197597/11023035/a2f8733e-8622-11e5-84df-49a3d9425938.png">
 
+
 ## How To Use?
 
 - Go to your project on GitHub > Settings > Webhooks & services > Add Webhook
@@ -68,6 +69,10 @@ npm install
 npm start
 # Follow the instructions there
 ```
+
+Alternatively, click the button below:
+
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/facebook/mention-bot)
 
 ## License
 mention-bot is BSD-licensed. We also provide an additional patent grant.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,5 @@
+{
+  "name": "Mention Bot",
+  "repository": "https://github.com/facebook/mention-bot",
+  "logo": "https://avatars3.githubusercontent.com/u/15710697?v=3&s=400"
+}


### PR DESCRIPTION
Hey, I implemented the button mentioned in issue #4 - not sure if you wanted it near the top or bottom, so I put it under "How to contribute or run your own bot." The app.json is very basic and I don't have a good source for the mention-bot logo, so it's linked to the github avatars - if a better source is available (along with a desired description, etc) I'd be happy to add it in.