### PR TITLE
Heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mention-bot
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 Do you have a GitHub project that is too big for people to subscribe to all the notifications? The mention bot will automatically mention potential reviewers on pull requests. It helps getting faster turnaround on pull requests by involving the right people early on.
 
 <img width="769" src="https://cloud.githubusercontent.com/assets/197597/11023035/a2f8733e-8622-11e5-84df-49a3d9425938.png">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # mention-bot
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
-
 Do you have a GitHub project that is too big for people to subscribe to all the notifications? The mention bot will automatically mention potential reviewers on pull requests. It helps getting faster turnaround on pull requests by involving the right people early on.
 
 <img width="769" src="https://cloud.githubusercontent.com/assets/197597/11023035/a2f8733e-8622-11e5-84df-49a3d9425938.png">
@@ -74,7 +72,7 @@ npm start
 
 Alternatively, click the button below:
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/facebook/mention-bot)
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
 
 ## License
 mention-bot is BSD-licensed. We also provide an additional patent grant.

--- a/app.json
+++ b/app.json
@@ -1,5 +1,13 @@
 {
-  "name": "Mention Bot",
+  "name": "mention-bot",
+  "description": "Automatically mention potential reviewers on pull requests.",
   "repository": "https://github.com/facebook/mention-bot",
-  "logo": "https://avatars3.githubusercontent.com/u/15710697?v=3&s=400"
+  "logo": "https://avatars0.githubusercontent.com/u/15710697",
+  "keywords": ["node", "express", "github", "pull requests"],
+  "env": {
+    "GITHUB_TOKEN": {
+      "description": "A token generated for the account which will comment on your pull requests.",
+      "required": true
+    }
+  }
 }


### PR DESCRIPTION
Fixes #4 

Adds a "Deploy to Heroku" button to the readme, along with the required `app.json` file.

![](http://snaps.michaelwarkentin.com.s3.amazonaws.com/mwarkentinmention-bot_at_heroku-button_2015-11-19_16-09-04.png)
![](http://snaps.michaelwarkentin.com.s3.amazonaws.com/Create_a_New_App__Heroku_2015-11-19_16-09-26.png)