### PR TITLE
Implement repo config setting for max number of reviewers to mention

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -1,5 +1,6 @@
 ```js
 {
-  "userBlacklist": [] // users in this list will never be mentioned by mention-bot
+  "userBlacklist": [], // users in this list will never be mentioned by mention-bot
+  "maxReviewers":   3  // max number of users to mention
 }
 ```

--- a/mention-bot.js
+++ b/mention-bot.js
@@ -301,7 +301,7 @@ function guessOwners(
     .filter(function(owner) {
       return config.userBlacklist.indexOf(owner) === -1;
     })
-    .slice(0, 3);
+    .slice(0, config.maxReviewers);
 }
 
 function guessOwnersForPullRequest(

--- a/server.js
+++ b/server.js
@@ -84,6 +84,20 @@ function defaultMessageGenerator(reviewers) {
   );
 };
 
+/**
+  * Merge object 2 with object 1.
+  * Any property that both object 1 and 2 have will be overwritten.
+  */
+function merge(o1, o2) {
+  if (typeof o1 === 'object' && typeof o2 === 'object') {
+    for (var prop in o2) {
+      if (o2.hasOwnProperty(prop)) {
+        o1[prop] = o2[prop];
+      }
+    }
+  }
+}
+
 app.post('/', function(req, res) {
   req.pipe(bl(function(err, body) {
     var data = {};
@@ -108,11 +122,15 @@ app.post('/', function(req, res) {
     }, function(err, configRes) {
       // default config
       var repoConfig = {
-        userBlacklist: []
+        userBlacklist: [],
+        maxReviewers: 3
       };
 
       if (!err && configRes) {
-        try { repoConfig = JSON.parse(configRes); } catch (e) {}
+        try {
+          merge(repoConfig, JSON.parse(configRes));
+        } catch (e) {}
+
       }
 
       var reviewers = mentionBot.guessOwnersForPullRequest(


### PR DESCRIPTION
Adds a new repo-specific setting `maxReviewers` for the max number of users to mention. Default value is 3.