### PR TITLE
Additional Protocol&Port options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,16 @@ If you want to run the bot on your GitHub Enterprise instance, add the GHE host 
 }
 ```
 
+If you use `http` protocol, the config section like this:
+
+```json
+"config": {
+  "gheHost": "github.my-GHE-enabled-company.com",
+  "ghePathPrefix": "/api/v3",
+  "gheProtocol": "http",
+  "ghePort": 80
+}
+```
+
 ## License
 mention-bot is BSD-licensed. We also provide an additional patent grant.

--- a/server.js
+++ b/server.js
@@ -51,7 +51,9 @@ if (!process.env.GITHUB_USER) {
 var github = new GitHubApi({
   version: '3.0.0',
   host: config.gheHost,
-  pathPrefix: config.ghePathPrefix
+  pathPrefix: config.ghePathPrefix,
+  protocol: config.gheProtocol || 'https',
+  port: config.ghePort || '443'
 });
 
 github.authenticate({


### PR DESCRIPTION
We use GitHub Enterprise instance. but use `http` protocol and `80` port.

The default's `http` and `443`. will raise some error. like this:

```
connect ECONNREFUSED 192.168.11.29:443
```
