### PR TITLE
fix: Object spread issue

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["react"]
+  "presets": ["react"],
+  "plugins": ["babel-plugin-transform-object-rest-spread"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+server-compiled.js

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "facebook/mention-bot",
   "scripts": {
     "test": "flow && jest",
-    "start": "babel server.js --out-file server-compiled.js && node server-compiled.js"
+    "start": "node run-server.js"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "facebook/mention-bot",
   "scripts": {
     "test": "flow && jest",
-    "start": "node server.js"
+    "start": "babel server.js --out-file server-compiled.js && node server-compiled.js"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest"
@@ -14,6 +14,7 @@
   "dependencies": {
     "babel-core": "^6.0.0",
     "babel-jest": "^6.0.1",
+    "babel-plugin-transform-object-rest-spread": "^6.1.18",
     "babel-preset-react": "^6.1.2",
     "bl": "^1.0.0",
     "download-file-sync": "^1.0.3",

--- a/run-server.js
+++ b/run-server.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+require('babel-core/register');
+require('./server.js');

--- a/server.js
+++ b/server.js
@@ -7,8 +7,6 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
-require('babel-core/register');
-
 var bl = require('bl');
 var config = require('./package.json').config;
 var express = require('express');


### PR DESCRIPTION
- Updates dependencies with the object spread transform
- Adds plugins to babelrc
- Updates `npm start` to include the babel transform

Fixes #48

I opted with using Babel to transform the `server.js` instead of `babel-node` because as noted in Babel's documentation it is:
> Not meant for production use

Nit-pick away! :smile: 