### PR TITLE
:art: cleanup: Remove compiled server ref in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules
 npm-debug.log
-server-compiled.js


### PR DESCRIPTION
Removes `server-compiled.js` from the git ignore files now that it is not being used.