### PR TITLE
Implement required organizations in config.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -8,6 +8,7 @@
       "files": ["src/js/**/*.js"] // The array of file globs associated with the user
     }
   ], // users will always be mentioned based on file glob
-  "userBlacklist": [] // users in this list will never be mentioned by mention-bot
+  "userBlacklist": [], // users in this list will never be mentioned by mention-bot
+  "requiredOrgs": [] // mention-bot will only mention user who are a member of one of these organizations
 }
 ```

--- a/server.js
+++ b/server.js
@@ -113,6 +113,7 @@ async function work(body) {
     numFilesToCheck: 5,
     userBlacklist: [],
     userWhitelist: [],
+    requiredOrgs: [],
   };
 
   // request config from repo
@@ -134,7 +135,8 @@ async function work(body) {
     data.pull_request.number, // 23
     data.pull_request.user.login, // 'mention-bot'
     data.pull_request.base.ref, // 'master'
-    repoConfig
+    repoConfig,
+    github
   );
 
   console.log(data.pull_request.html_url, reviewers);


### PR DESCRIPTION
This PR adds a config option called `requiredOrgs`. In order to be mentioned by the bot, a user will have to be in one of the organizations in the `requiredOrgs` list.

Since this change requires making requests from within `mention-bot.js`, I had to pass in the GitHub API to `guessOwnersForPullRequest()`.