### PR TITLE
Catch rejected promise when .mention-bot is missing

### DIFF
--- a/server.js
+++ b/server.js
@@ -118,21 +118,19 @@ async function work(body) {
     requiredOrgs: [],
   };
 
-  // request config from repo
-  var configRes = await getRepoConfig({
-    user: data.repository.owner.login,
-    repo: data.repository.name,
-    path: CONFIG_PATH,
-    headers: {
-      Accept: 'application/vnd.github.v3.raw'
-    }
-  });
+  try {
+    // request config from repo
+    var configRes = await getRepoConfig({
+      user: data.repository.owner.login,
+      repo: data.repository.name,
+      path: CONFIG_PATH,
+      headers: {
+        Accept: 'application/vnd.github.v3.raw'
+      }
+    });
 
-  if (configRes) {
-    try {
-      repoConfig = {...repoConfig, ...JSON.parse(configRes)};
-    } catch (e) {}
-  }
+    repoConfig = {...repoConfig, ...JSON.parse(configRes)};
+  } catch (e) {}
 
   var reviewers = await mentionBot.guessOwnersForPullRequest(
     data.repository.html_url, // 'https://github.com/fbsamples/bot-testing'


### PR DESCRIPTION
If the repo doesn't contain a .mention-bot file this promise will be
rejected with an error from github. `await` will throw when its
promise gets rejected.

Will partly fix #61. I'll post another PR which will fix another issue.