### PR TITLE
Increase maxBuffer when downloading files

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -24,7 +24,7 @@ async function downloadFileAsync(url: string, cookies: ?string): Promise<string>
     }
 
     require('child_process')
-      .execFile('curl', args, {encoding: 'utf8'}, function(error, stdout, stderr) {
+      .execFile('curl', args, {encoding: 'utf8', maxBuffer: 1000 * 1024}, function(error, stdout, stderr) {
         if (error) {
           reject(error);
         } else {


### PR DESCRIPTION
Getting a lot of `Error: stdout maxBuffer exceeded.`-errors when
downloading the files. Not sure what a good limit is, but this should be
more than enough.

Also, helps with fixing #61.