### PR TITLE
Implement file blacklist.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -8,6 +8,7 @@
       "files": ["src/js/**/*.js"] // The array of file globs associated with the user
     }
   ], // users will always be mentioned based on file glob
+  "fileBlacklist": ["*.md"], // mention-bot will ignore any files that match these file globs
   "userBlacklist": [], // users in this list will never be mentioned by mention-bot
   "requiredOrgs": [] // mention-bot will only mention user who are a member of one of these organizations
 }

--- a/mention-bot.js
+++ b/mention-bot.js
@@ -427,6 +427,12 @@ async function guessOwnersForPullRequest(
     var countB = b.deletedLines.length;
     return countA > countB ? -1 : (countA < countB ? 1 : 0);
   });
+  // remove files that match any of the globs in the file blacklist config
+  config.fileBlacklist.forEach(function(glob) {
+    files = files.filter(function(file) {
+      return !minimatch(file.path, glob);
+    });
+  });
   files = files.slice(0, config.numFilesToCheck);
 
   var blames = {};

--- a/server.js
+++ b/server.js
@@ -119,6 +119,7 @@ async function work(body) {
     numFilesToCheck: 5,
     userBlacklist: [],
     userWhitelist: [],
+    fileBlacklist: [],
     requiredOrgs: [],
   };
 


### PR DESCRIPTION
Adds a `fileBlacklist` option to the repo config. mention-bot will ignore any files matched by the globs in the blacklist.