### PR TITLE
Mock cookieJar.js manually

### DIFF
--- a/__mocks__/cookieJar.js
+++ b/__mocks__/cookieJar.js
@@ -1,0 +1,10 @@
+var cookieJarMock = jest.genMockFromModule('../cookieJar.js');
+cookieJarMock.mockImplementation(() => { 
+  return {
+    cookies: {},
+    get: () => { return {}; },
+    parseHeaders: () => { return {}; }
+  };
+});
+
+module.exports = cookieJarMock;


### PR DESCRIPTION
I got this error when I run `npm test` in my local (because of `$GITHUB_USER`),

```sh
$ npm install
$ npm test
TypeError: /Users/user/js/mention-bot/__tests__/github-mention-test.js: /Users/user/js/mention-bot/mention-bot.js: /Users/user/js/mention-bot/
githubAuthCookies.js: Cannot read property 'logged_in' of undefined
npm ERR! Test failed.  See above for more details.
```

and fix this by adding `__mocks__/cookieJar.js`.