### PR TITLE
Added a global required organization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Alternatively, click the button below:
 
 If you would like the mention-bot to function on private repositories, set the `GITHUB_USER` and `GITHUB_PASSWORD` environment variables. You must disable two-factor authentication or you will receive a console log like this: `Login to ${USERNAME} failed`.
 
+You can also set a `REQUIRED_ORG` environment variable, so you don't have to configure it in each repository of your organization.
+
 You can also build deploy it as a Docker image:
 
 ```bash

--- a/server.js
+++ b/server.js
@@ -140,6 +140,10 @@ async function work(body) {
     console.error(e);
   }
 
+  if (process.env.REQUIRED_ORG) {
+    repoConfig.requiredOrgs.push(process.env.REQUIRED_ORG);
+  }
+
   if (repoConfig.userBlacklistForPR.indexOf(data.pull_request.user.login) >= 0) {
     console.log('Skipping because blacklisted user created Pull Request.');
     return;


### PR DESCRIPTION
In our case here at @ContaAzul, we run our own mention-bot to support
our private repos.

In that case, it would be great to set a required organization globally
instead of configuring it for each repo (we have lot's of them).

This PR should fix that, don't know if it's the best way of doing this,
though.

I din't found any tests for `requiredOrgs`, so I leave it as is.