### PR TITLE
Fallback notify users

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
       "files": ["src/js/**/*.js"] // The array of file globs associated with the user
     }
   ], // users will always be mentioned based on file glob
+  "fallbackNotifyForPaths": [
+    {
+      "name": "ghuser", // The user's Github username
+      "files": ["src/js/**/*.js"] // The array of file globs associated with the user
+    }
+  ], // users will be mentioned based on file glob if no other user was found
   "findPotentialReviewers": true, // mention-bot will try to find potential reviewers based on files history, if disabled, `alwaysNotifyForPaths` is used instead
   "fileBlacklist": ["*.md"], // mention-bot will ignore any files that match these file globs
   "userBlacklist": [], // users in this list will never be mentioned by mention-bot

--- a/__tests__/github-mention-test.js
+++ b/__tests__/github-mention-test.js
@@ -126,8 +126,49 @@ describe('Github Mention', function() {
         }
       );
 
-      owners.then(function(owners) {
+    pit('Should contain testname in owners from fallback', function() {
+      mentionBot.enableCachingForDebugging = true;
+      return mentionBot.guessOwnersForPullRequest(
+        'https://github.com/fbsamples/bot-testing',
+        95,
+        'mention-bot',
+        'master',
+        {
+          maxReviewers: 3,
+          userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true,
+          fallbackNotifyForPaths: [
+            {
+              name: 'ghuser',
+              files: ['*.js']
+            }
+          ]
+        }
+      ).then(function(owners) {
         expect(owners.indexOf('ghuser')).toBeGreaterThan(-1);
+      });
+    });
+
+    pit('Should not contain testname in owners from fallback when fallback is missing', function() {
+      mentionBot.enableCachingForDebugging = true;
+      return mentionBot.guessOwnersForPullRequest(
+        'https://github.com/fbsamples/bot-testing',
+        95,
+        'mention-bot',
+        'master',
+        {
+          maxReviewers: 3,
+          userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true
+        }
+      ).then(function (owners) {
+        expect(owners.indexOf('ghuser')).toEqual(-1);
       });
     });
   });

--- a/__tests__/github-mention-test.js
+++ b/__tests__/github-mention-test.js
@@ -46,70 +46,10 @@ describe('Github Mention', function() {
   });
 
   describe('CompleteFlow', function() {
-    beforeEach(function() {
-      jest.setMock('download-file-sync', function(url) {
-        return getFile('3238.diff');
-      });
-    });
 
-    it('Gets correct users with default config options', function() {
+    pit('Gets correct users with default config options', function() {
       mentionBot.enableCachingForDebugging = true;
-      var owners = mentionBot.guessOwnersForPullRequest(
-        'https://github.com/facebook/react-native',
-        3238,
-        'mention-bot',
-        'master',
-        {
-          maxReviewers: 3,
-          userBlacklist: []
-        }
-      );
-      owners.then(function(owners) {
-        expect(owners).toEqual(['corbt', 'vjeux', 'sahrens']);
-      });
-    });
-
-    it('Gets correct users if `findPotentialReviewers` option is disabled', function() {
-        mentionBot.enableCachingForDebugging = true;
-        var owners = mentionBot.guessOwnersForPullRequest(
-          'https://github.com/facebook/react-native',
-          3238,
-          'mention-bot',
-          'master',
-          {
-            alwaysNotifyForPaths: [{
-              name: 'jcsmorais',
-              files: ['website/server']
-            }],
-            findPotentialReviewers: false
-          }
-        );
-        owners.then(function(owners) {
-            expect(owners).toEqual(['jcsmorais']);
-        });
-      });
-
-    it('Messages 5 users from config option maxUsersToPing', function() {
-      mentionBot.enableCachingForDebugging = true;
-      var owners = mentionBot.guessOwnersForPullRequest(
-        'https://github.com/facebook/react-native',
-        3238,
-        'mention-bot',
-        'master',
-        {
-          maxReviewers: 5,
-          userBlacklist: []
-        }
-      );
-
-      owners.then(function(owners) {
-        expect(owners.length).toEqual(5);
-      });
-    });
-
-    it('Should contain testname in owners from whitelist', function() {
-      mentionBot.enableCachingForDebugging = true;
-      var owners = mentionBot.guessOwnersForPullRequest(
+      return mentionBot.guessOwnersForPullRequest(
         'https://github.com/facebook/react-native',
         3238,
         'mention-bot',
@@ -117,6 +57,74 @@ describe('Github Mention', function() {
         {
           maxReviewers: 3,
           userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true,
+        }
+      ).then(function(owners) {
+        expect(owners).toEqual(['corbt', 'vjeux', 'sahrens']);
+      });
+    });
+
+    pit('Gets correct users if `findPotentialReviewers` option is disabled', function() {
+        mentionBot.enableCachingForDebugging = true;
+        return mentionBot.guessOwnersForPullRequest(
+          'https://github.com/facebook/react-native',
+          3238,
+          'mention-bot',
+          'master',
+          {
+            maxReviewers: 3,
+            userBlacklist: [],
+            fileBlacklist: [],
+            requiredOrgs: [],
+            numFilesToCheck: 5,
+            findPotentialReviewers: false,
+            alwaysNotifyForPaths: [{
+              name: 'jcsmorais',
+              files: ['website/server/*']
+            }]
+          }
+        ).then(function(owners) {
+          expect(owners).toEqual(['jcsmorais']);
+        });
+      });
+
+    pit('Messages 5 users from config option maxUsersToPing', function() {
+      mentionBot.enableCachingForDebugging = true;
+      return mentionBot.guessOwnersForPullRequest(
+        'https://github.com/facebook/react-native',
+        3238,
+        'mention-bot',
+        'master',
+        {
+          maxReviewers: 5,
+          userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true,
+        }
+      ).then(function(owners) {
+        expect(owners.length).toEqual(5);
+      });
+    });
+
+    pit('Should contain testname in owners from whitelist', function() {
+      mentionBot.enableCachingForDebugging = true;
+      return mentionBot.guessOwnersForPullRequest(
+        'https://github.com/facebook/react-native',
+        3238,
+        'mention-bot',
+        'master',
+        {
+          maxReviewers: 3,
+          userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true,
           alwaysNotifyForPaths: [
             {
               name: 'ghuser',
@@ -124,7 +132,10 @@ describe('Github Mention', function() {
             }
           ]
         }
-      );
+      ).then(function(owners) {
+        expect(owners.indexOf('ghuser')).toBeGreaterThan(-1);
+      });
+    });
 
     pit('Should contain testname in owners from fallback', function() {
       mentionBot.enableCachingForDebugging = true;

--- a/cache/https---github.com-fbsamples-bot-testing-blame-master-hello-world.js
+++ b/cache/https---github.com-fbsamples-bot-testing-blame-master-hello-world.js
@@ -1,0 +1,1 @@
+{"error":"Not Found"}

--- a/cache/https---github.com-fbsamples-bot-testing-pull-95.diff
+++ b/cache/https---github.com-fbsamples-bot-testing-pull-95.diff
@@ -1,0 +1,7 @@
+diff --git a/hello-world.js b/hello-world.js
+new file mode 100644
+index 0000000..a420803
+--- /dev/null
++++ b/hello-world.js
+@@ -0,0 +1 @@
++console.log('Hello World!');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "main": "./run-mention-bot.js",
   "engines": {
-     "node": ">=4"
+    "node": ">=4"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
Add fallback users to config.
When no other user is found the fallback users will be notified based on file glob.

In a large projects, with many developers and a lot of commits, the `alwaysNotifyForPaths` feature can easily generate too many mentions for some users.
What this PR tries to solve is the ability to configure fallback users when no other user is found.

_side note_
- As I tried to run all the tests, I saw that any test would pass even with failing `expect` cases.
That was due to `Promise`-based tests, so I fixed them by using `pit` instead of `it`for testing.
- I couldn't get flow to work as expected. I got a lot of errors from `babel` when trying to check types. By "googling" it seems that other people experience the same thing in other projects as well (https://gist.github.com/ELLIOTTCABLE/96c2f2f5b10ca62fcfc6). I ran flow on each file manually to check that everything was done right.