### PR TITLE
Allow github host and prefix to be set via environment variable

### DIFF
--- a/githubAuthCookies.js
+++ b/githubAuthCookies.js
@@ -17,7 +17,7 @@ var childProcess = require('child_process');
 var CookieJar = require('./cookieJar');
 var jar = new CookieJar();
 
-var ghHost = config.gheHost || 'github.com';
+var ghHost = process.env.GITHUB_HOST || config.gheHost || 'github.com';
 var ghProtocol = config.gheProtocol || 'https';
 
 /**

--- a/server.js
+++ b/server.js
@@ -50,8 +50,8 @@ if (!process.env.GITHUB_USER) {
 
 var github = new GitHubApi({
   version: '3.0.0',
-  host: config.gheHost,
-  pathPrefix: config.ghePathPrefix,
+  host: process.env.GITHUB_HOST || config.gheHost,
+  pathPrefix: process.env.GITHUB_API_PREFIX || config.ghePathPrefix,
   protocol: config.gheProtocol || 'https',
   port: config.ghePort || '443'
 });


### PR DESCRIPTION
Rather than edit the package.json config, it's nice to use environment variables, particularly when running in a docker container.
