### PR TITLE
Check the org members if the repo is private

### DIFF
--- a/__tests__/github-mention-test.js
+++ b/__tests__/github-mention-test.js
@@ -110,7 +110,7 @@ describe('Github Mention', function() {
       });
     });
 
-    pit('Handles pagination', function() {
+    pit('Handles pagination when getting the org members', function() {
       mentionBot.enableCachingForDebugging = true;
       var onCall = 0;
 
@@ -167,6 +167,36 @@ describe('Github Mention', function() {
           page: 1,
           per_page: 100
         });
+        expect(owners).toEqual(['corbt', 'vjeux', 'sahrens']);
+      });
+    });
+
+    pit('Does not get the org members if there is no org', function() {
+      mentionBot.enableCachingForDebugging = true;
+      var githubMock = {
+        orgs: {
+          getMembers: jest.genMockFunction()
+        }
+      };
+
+      return mentionBot.guessOwnersForPullRequest(
+        'https://github.com/facebook/react-native',
+        3238,
+        'mention-bot',
+        'master',
+        true,
+        undefined,
+        {
+          maxReviewers: 3,
+          userBlacklist: [],
+          fileBlacklist: [],
+          requiredOrgs: [],
+          numFilesToCheck: 5,
+          findPotentialReviewers: true,
+        },
+        githubMock
+      ).then(function(owners) {
+        expect(githubMock.orgs.getMembers.mock.calls.length).toBe(0);
         expect(owners).toEqual(['corbt', 'vjeux', 'sahrens']);
       });
     });

--- a/mention-bot.js
+++ b/mention-bot.js
@@ -374,10 +374,10 @@ async function filterRequiredOrgs(
 
 async function filterPrivateRepo(
   owners: Array<string>,
-  ownerOrg: string,
+  org: string,
   github: Object
 ): Promise<Array<string>> {
-  var currentMembers = await getMembersOfOrg(ownerOrg, github, 0);
+  var currentMembers = await getMembersOfOrg(org, github, 0);
 
   return owners.filter(function(owner, index) {
     // user passes if they are still in the org
@@ -420,7 +420,7 @@ async function guessOwners(
   defaultOwners: Array<string>,
   fallbackOwners: Array<string>,
   privateRepo: boolean,
-  ownerOrg: string,
+  org: ?string,
   config: Object,
   github: Object
 ): Promise<Array<string>> {
@@ -453,8 +453,8 @@ async function guessOwners(
     owners = await filterRequiredOrgs(owners, config, github);
   }
 
-  if (privateRepo) {
-    owners = await filterPrivateRepo(owners, ownerOrg, github);
+  if (privateRepo && org != null) {
+    owners = await filterPrivateRepo(owners, org, github);
   }
 
   if (owners.length === 0) {
@@ -475,7 +475,7 @@ async function guessOwnersForPullRequest(
   creator: string,
   targetBranch: string,
   privateRepo: boolean,
-  ownerOrg: string,
+  org: ?string,
   config: Object,
   github: Object
 ): Promise<Array<string>> {
@@ -519,7 +519,7 @@ async function guessOwnersForPullRequest(
 
   // This is the line that implements the actual algorithm, all the lines
   // before are there to fetch and extract the data needed.
-  return guessOwners(files, blames, creator, defaultOwners, fallbackOwners, privateRepo, ownerOrg, config, github);
+  return guessOwners(files, blames, creator, defaultOwners, fallbackOwners, privateRepo, org, config, github);
 }
 
 module.exports = {

--- a/server.js
+++ b/server.js
@@ -151,13 +151,19 @@ async function work(body) {
     return;
   }
 
+  var org = null;
+
+  if(data.organization) {
+    org = data.organization.login;
+  }
+
   var reviewers = await mentionBot.guessOwnersForPullRequest(
     data.repository.html_url, // 'https://github.com/fbsamples/bot-testing'
     data.pull_request.number, // 23
     data.pull_request.user.login, // 'mention-bot'
     data.pull_request.base.ref, // 'master'
     data.repository.private, //true or false
-    data.organization.login, //the owner of the repo
+    org, //the org name of the repo
     repoConfig,
     github
   );

--- a/server.js
+++ b/server.js
@@ -156,6 +156,8 @@ async function work(body) {
     data.pull_request.number, // 23
     data.pull_request.user.login, // 'mention-bot'
     data.pull_request.base.ref, // 'master'
+    data.repository.private, //true or false
+    data.organization.login, //the owner of the repo
     repoConfig,
     github
   );


### PR DESCRIPTION
Fixes https://github.com/facebook/mention-bot/issues/104

If the PR is opened on a private repo, we do not want to mention users that are no longer part of that org
`requiredOrgs` does not work in this case unless every one publically lists that they are part of the org.

So now, if the PR is opened on a private repo
We get the list of all members of that org, and filter out any reviewers who do not appear on that list

Thanks :smile: 
