### PR TITLE
Custom message in the config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
 {
   "maxReviewers": 5, // Maximum  number of people to ping in the PR message, default is 3
   "numFilesToCheck": 10, // Number of files to check against, default is 5
-  "message": "@pullRequester, thanks! @reviwers, please review this.",
-             // custom message using @pullRequester and @reviwers
+  "message": "@pullRequester, thanks! @reviewers, please review this.",
+             // custom message using @pullRequester and @reviewers
   "alwaysNotifyForPaths": [
     {
       "name": "ghuser", // The user's Github username

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
 {
   "maxReviewers": 5, // Maximum  number of people to ping in the PR message, default is 3
   "numFilesToCheck": 10, // Number of files to check against, default is 5
+  "message": "@pullRequester, thanks! @reviwers, please review this.",
+             // custom message using @pullRequester and @reviwers
   "alwaysNotifyForPaths": [
     {
       "name": "ghuser", // The user's Github username

--- a/server.js
+++ b/server.js
@@ -89,7 +89,7 @@ function defaultMessageGenerator(reviewers, pullRequester) {
 }
 
 function configMessageGenerator(message, reviewers, pullRequester) {
-  // replace all @reviwers. message may have more than one '@reviwers'.
+  // replace all @reviewers. message may have more than one '@reviewers'.
   var withReviewers = message.replace(/@reviewers/g, buildMentionSentence(reviewers));
   // replace all @pullRequester, and return
   return withReviewers.replace(/@pullRequester/g, pullRequester);

--- a/server.js
+++ b/server.js
@@ -90,7 +90,7 @@ function defaultMessageGenerator(reviewers, pullRequester) {
 
 function configMessageGenerator(message, reviewers, pullRequester) {
   // replace all @reviwers. message may have more than one '@reviwers'.
-  var withReviewers = message.replace(/@reviwers/g, buildMentionSentence(reviewers));
+  var withReviewers = message.replace(/@reviewers/g, buildMentionSentence(reviewers));
   // replace all @pullRequester, and return
   return withReviewers.replace(/@pullRequester/g, pullRequester);
 }

--- a/server.js
+++ b/server.js
@@ -89,9 +89,7 @@ function defaultMessageGenerator(reviewers, pullRequester) {
 }
 
 function configMessageGenerator(message, reviewers, pullRequester) {
-  // replace all @reviewers. message may have more than one '@reviewers'.
   var withReviewers = message.replace(/@reviewers/g, buildMentionSentence(reviewers));
-  // replace all @pullRequester, and return
   return withReviewers.replace(/@pullRequester/g, pullRequester);
 }
 
@@ -186,7 +184,6 @@ async function work(body) {
 
   var message = null;
   if (repoConfig.message) {
-    // generate message using repoConfig.message if it is set
     message = configMessageGenerator(
       repoConfig.message,
       reviewers,

--- a/server.js
+++ b/server.js
@@ -186,7 +186,7 @@ async function work(body) {
 
   var message = null;
   if (repoConfig.message) {
-    // generate message using repoConfig.message
+    // generate message using repoConfig.message if it is set
     message = configMessageGenerator(
       repoConfig.message,
       reviewers,

--- a/server.js
+++ b/server.js
@@ -88,6 +88,13 @@ function defaultMessageGenerator(reviewers, pullRequester) {
   );
 }
 
+function configMessageGenerator(message, reviewers, pullRequester) {
+  // replace all @reviwers. message may have more than one '@reviwers'.
+  var withReviewers = message.replace(/@reviwers/g, buildMentionSentence(reviewers));
+  // replace all @pullRequester, and return
+  return withReviewers.replace(/@pullRequester/g, pullRequester);
+}
+
 function getRepoConfig(request) {
   return new Promise(function(resolve, reject) {
     github.repos.getContent(request, function(err, result) {
@@ -177,16 +184,28 @@ async function work(body) {
     return;
   }
 
-  github.issues.createComment({
-    user: data.repository.owner.login, // 'fbsamples'
-    repo: data.repository.name, // 'bot-testing'
-    number: data.pull_request.number, // 23
-    body: messageGenerator(
+  var message = null;
+  if (repoConfig.message) {
+    // generate message using repoConfig.message
+    message = configMessageGenerator(
+      repoConfig.message,
+      reviewers,
+      '@' + data.pull_request.user.login
+    );
+  } else {
+    message = messageGenerator(
       reviewers,
       '@' + data.pull_request.user.login, // pull-requester
       buildMentionSentence,
       defaultMessageGenerator
-    )
+    );
+  }
+
+  github.issues.createComment({
+    user: data.repository.owner.login, // 'fbsamples'
+    repo: data.repository.name, // 'bot-testing'
+    number: data.pull_request.number, // 23
+    body: message
   });
 
   return;


### PR DESCRIPTION
#111 
- Add quick example in the README.md
- Added repoConfig.message based ConfigMessageGenerator.

Without config/no message in config:

![image](https://cloud.githubusercontent.com/assets/901975/14590844/08b16598-0538-11e6-9152-c0540dff029d.png)

With config file:
```
{
  "maxReviewers": 5, // Maximum  number of people to ping in the PR message, default is 3
  "numFilesToCheck": 10, // Number of files to check against, default is 5
  "message": "@pullRequester, cool! @reviewers, please check this out for @pullRequester."
}
```

![image](https://cloud.githubusercontent.com/assets/901975/14590872/4db0f1ea-0538-11e6-9aff-93b7002c6976.png)