### PR TITLE
Add skipTitle Configuration. Fixes #121

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
   "requiredOrgs": [], // mention-bot will only mention user who are a member of one of these organizations
   "actions": ["opened"], // List of PR actions that mention-bot will listen to, default is "opened"
   "skipAlreadyAssignedPR": false, // mention-bot will ignore already assigned PR's
-  "assignToReviewer": false  // mention-bot assigns the most appropriate reviewer for PR
+  "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
+  "skipTitle": "" // mention-bot will ignore PR that includes text in the title
 }
 ```
 
@@ -122,7 +123,7 @@ docker run -e GITHUB_USER="a" -p 5000:5000  mention-bot
 
 ## Configuring a custom message
 
-If you want to change the default message, you can write your custom logic in [message.js](https://github.com/facebook/mention-bot/blob/master/message.js), or add 'message' in the [.mention-bot configuration](#configuration) file. 
+If you want to change the default message, you can write your custom logic in [message.js](https://github.com/facebook/mention-bot/blob/master/message.js), or add 'message' in the [.mention-bot configuration](#configuration) file.
 
 ## How to run the bot on GitHub Enterprise
 

--- a/__tests__/data/23.webhook
+++ b/__tests__/data/23.webhook
@@ -11,7 +11,7 @@
     "number": 23,
     "state": "open",
     "locked": false,
-    "title": "Update README.md",
+    "title": "github-mention-bot testing ground",
     "user": {
       "login": "vjeux",
       "id": 197597,

--- a/server.js
+++ b/server.js
@@ -125,6 +125,7 @@ async function work(body) {
     actions: ['opened'],
     skipAlreadyAssignedPR: false,
     assignToReviewer: false,
+    skipTitle: "",
   };
 
   try {
@@ -148,6 +149,12 @@ async function work(body) {
       'Skipping because action is ' + data.action + '.',
       'We only care about: "' + repoConfig.actions.join("', '") + '"'
     );
+    return;
+  }
+
+  if (repoConfig.skipTitle &&
+      data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
+    console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle)
     return;
   }
 


### PR DESCRIPTION
Add `skipTitle` configuration option to skip mention-bot if the PR title contains specific text.

Example:
```
{
  "skipTitle": "WIP"
}
```