### PR TITLE
Add GHE config via env vars

### DIFF
--- a/config.js
+++ b/config.js
@@ -6,9 +6,9 @@ var configJson = require('./config.json');
 var mergedConfig = Object.assign(packageConfig, configJson);
 
 exports.github = {
-  host: mergedConfig.gheHost || 'github.com',
-  apiHost: mergedConfig.gheHost || 'api.github.com',
-  protocol: mergedConfig.gheProtocol || 'https',
-  pathPrefix: mergedConfig.ghePathPrefix,
-  port: mergedConfig.ghePort || 443
+  host: process.env.GHE_HOST || mergedConfig.gheHost || 'github.com',
+  apiHost: process.env.GHE_API_HOST || mergedConfig.gheHost || 'api.github.com',
+  protocol: process.env.GHE_PROTOCOL || mergedConfig.gheProtocol || 'https',
+  pathPrefix: process.env.GHE_PATH_PREFIX || mergedConfig.ghePathPrefix,
+  port: process.env.GHE_PORT || mergedConfig.ghePort || 443
 };


### PR DESCRIPTION
Makes it easier to deploy mention bot for GHE users without having to
create a custom configuration file and make new docker images.