### PR TITLE
Add withLabel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
   "skipAlreadyAssignedPR": false, // mention-bot will ignore already assigned PR's
   "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
   "skipTitle": "", // mention-bot will ignore PR that includes text in the title,
+  "withLabel": "", // mention-bot will only consider PR's with this label. Must set actions to ["labeled"].
   "delayed": false, // mention-bot will wait to comment until specified time in `delayedUntil` value
   "delayedUntil": "3d", // Used if delayed is equal true, permitted values are: minutes, hours, or days, e.g.: '3 days', '40 minutes', '1 hour', '3d', '1h', '10m'
   "skipCollaboratorPR": false, // mention-bot will ignore if PR is made by collaborator

--- a/server.js
+++ b/server.js
@@ -129,6 +129,7 @@ async function work(body) {
     delayedUntil: '3d',
     assignToReviewer: false,
     skipTitle: '',
+    withLabel: '',
     skipCollaboratorPR: false,
   };
 
@@ -154,6 +155,12 @@ async function work(body) {
         'Skipping because action is ' + data.action + '.',
         'We only care about: "' + repoConfig.actions.join("', '") + '"'
       );
+      return false;
+    }
+
+    if (repoConfig.withLabel && data.label &&
+        data.label.name != repoConfig.withLabel) {
+      console.log('Skipping because pull request does not have label: ' + repoConfig.withLabel);
       return false;
     }
 


### PR DESCRIPTION
Our workflow is to open pull requests early so everyone knows who's working on what. When the PR is ready for review, a specific label is added.

This PR adds functionality to set a label with the `withLabel` configuration. This works best when setting the `actions` configuration to `["labeled"]`.