### PR TITLE
Read config from pull request

### DIFF
--- a/server.js
+++ b/server.js
@@ -138,6 +138,7 @@ async function work(body) {
       user: data.repository.owner.login,
       repo: data.repository.name,
       path: CONFIG_PATH,
+      ref: data.pull_request.head.ref,
       headers: {
         Accept: 'application/vnd.github.v3.raw'
       }


### PR DESCRIPTION
This changes the behavior of mention-bot. Instead of always reading the `.mention-bot` file from the master branch, it uses the `.mention-bot` file from the pull request.

This makes it easy to test new configurations without having to commit on master.