### PR TITLE
Use positive wording when suggesting reviewers

### DIFF
--- a/server.js
+++ b/server.js
@@ -80,7 +80,7 @@ function buildMentionSentence(reviewers) {
 function defaultMessageGenerator(reviewers, pullRequester) {
   return util.format(
     '%s, thanks for your PR! ' +
-    'By analyzing the blame information on this pull request' +
+    'By analyzing the annotation information on this pull request' +
     ', we identified %s to be%s potential reviewer%s',
     pullRequester,
     buildMentionSentence(reviewers),


### PR DESCRIPTION
Reading the word "blame" on the first comment of a pull request
could create a negative impression.
By changing "blame information" to "annotation information" we can
keep up the positive spirit of our contributors.