### PR TITLE
Fix for new files with 0 additions/deletions

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -78,7 +78,9 @@ function parseDiffFile(lines: Array<string>): FileInfo {
   }
 
   line = lines.pop();
-  if (startsWith(line, 'diff --git')) {
+  if (!line) {
+    // If the diff ends in an empty file with 0 additions or deletions, line will be null
+  } else if (startsWith(line, 'diff --git')) {
     lines.push(line);
   } else if (startsWith(line, 'Binary files')) {
     // We just ignore binary files (mostly images). If we want to improve the

--- a/mention-bot.js
+++ b/mention-bot.js
@@ -78,7 +78,9 @@ function parseDiffFile(lines: Array<string>): FileInfo {
   }
 
   line = lines.pop();
-  if (startsWith(line, 'Binary files')) {
+  if (startsWith(line, 'diff --git')) {
+    lines.push(line);
+  } else if (startsWith(line, 'Binary files')) {
     // We just ignore binary files (mostly images). If we want to improve the
     // precision in the future, we could look at the history of those files
     // to get more names.


### PR DESCRIPTION
The issue occurs when you add a file with 0 additions or deletions. In this case your diff will look like (see [here](https://patch-diff.githubusercontent.com/raw/brianbao/mention-bot/pull/1.diff):
```
diff --git a/test.js b/test.js
new file mode 100644
index 0000000..e69de29
```

The code pops off the 4th line without checking if the 4th line is a `diff --git`, so you'll get the following error when trying to parse the next file:
```
Error: Invalid line, should start with `diff --git a/`, instead got 
new file mode 100644
```

Additionally, if the diff ends in the empty file, the 4th line will be null, which will throw a `TypeError: Cannot read property 'substr' of undefined`.