### PR TITLE
add support for setting all reviewers as assignees

### DIFF
--- a/server.js
+++ b/server.js
@@ -280,7 +280,7 @@ async function work(body) {
       user: data.repository.owner.login, // 'fbsamples'
       repo: data.repository.name, // 'bot-testing'
       number: data.pull_request.number, // 23
-      assignee: reviewers[0]
+      assignees: reviewers
     }, function(err) {
       if (err) {
         if (typeof reject === 'function') {


### PR DESCRIPTION
This PR adds support for setting multiple assignees. It sets __all__ reviewers to be assignees using the `assignees` parameter [GitHub API docs](https://developer.github.com/v3/issues/#parameters-3).

closes #139 

@vjeux I could not find any existing tests for setting the first reviewer as an assignee. Should I also add a test for this?

(I signed the CLA a couple of minutes ago before submitting the PR. Maybe It takes another minute to be registered)