### PR TITLE
Prevent 'Server Timeout' when something goes wrong.

### DIFF
--- a/server.js
+++ b/server.js
@@ -356,7 +356,12 @@ async function work(body) {
 
 app.post('/', function(req, res) {
   req.pipe(bl(function(err, body) {
-    work(body).then(function() { res.end(); });
+    work(body)
+      .then(function() { res.end(); })
+      .catch(function(e) {
+        console.error(e.stack);
+        res.status(500).send('Internal Server Error');
+      });
   }));
 });
 


### PR DESCRIPTION
This logs an error to the console and responds with a status 500 when an exception is thrown in the work process.