### PR TITLE
Fixes issue where `.mention-bot` file shouldn't be required

### DIFF
--- a/server.js
+++ b/server.js
@@ -149,10 +149,10 @@ async function work(body) {
   } catch (e) {
     if (e.code === 404 &&
         e.message === '{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}') {
-      console.log('Skipping because the repo is not visible from mention-bot.');
-      return;
+      console.log('Couldn\'t find ' + CONFIG_PATH + ' in repo. Continuing with default configuration.');
+    } else {
+      console.error(e);
     }
-    console.error(e);
   }
 
   function isValid(repoConfig, data) {


### PR DESCRIPTION
This allows the work process to continue when a `.mention-bot` file doesn't exist in the target repo.