### PR TITLE
Correct the API to fetch orgs for the specified user

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -306,7 +306,7 @@ async function getOwnerOrgs(
   github: Object
 ): Promise<Array<string>> {
   return new Promise(function(resolve, reject) {
-    github.orgs.getFromUser({ user: owner }, function(err, result) {
+    github.orgs.getForUser({ user: owner }, function(err, result) {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
I believe it's the correct method name.

https://mikedeboer.github.io/node-github/#api-orgs-getForUser