### PR TITLE
#117 (Issue closed but not fixed yet) .mention-bot should recognize several PR actions 

### DIFF
--- a/server.js
+++ b/server.js
@@ -123,7 +123,7 @@ async function work(body) {
     fileBlacklist: [],
     requiredOrgs: [],
     findPotentialReviewers: true,
-    actions: ['opened'],
+    actions: ['opened','assigned', 'unassigned', 'labeled', 'unlabeled','edited','closed','reopened','synchronize'],
     skipAlreadyAssignedPR: false,
     skipAlreadyMentionedPR: false,
     delayed: false,


### PR DESCRIPTION
This patch is the solution for issue [#117](https://github.com/facebook/mention-bot/issues/117).

server.js had been fixed once to solve the issue, but mention-bot still does not understand PR actions except "opened" and logs on heroku would be like below;

```
2016-07-22T05:06:15.091259+00:00 app[web.1]: Skipping because action is synchronize. We only care about: "opened"
```

I have suffered same issues like #117, and I have found simple solutions to this.
With this patch, mention-bot will recognized all user-defined PR actions in .mention-bot file.

Would you please check and accept this PR if this is OK.

Many thanks and best regards.
Moses.
