### PR TITLE
Add feature to exclude a team from mentions on PR's made by a member

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
   "alwaysNotifyForPaths": [
     {
       "name": "ghuser", // The user's Github username
-      "files": ["src/js/**/*.js"] // The array of file globs associated with the user
+      "files": ["src/js/**/*.js"], // The array of file globs associated with the user
+      "skipTeamPrs": false // mention-bot will exclude the creator's own team from mentions
     }
   ], // users will always be mentioned based on file glob
   "fallbackNotifyForPaths": [
     {
       "name": "ghuser", // The user's Github username
-      "files": ["src/js/**/*.js"] // The array of file globs associated with the user
+      "files": ["src/js/**/*.js"], // The array of file globs associated with the user
+      "skipTeamPrs": false // mention-bot will exclude the creator's own team from mentions
     }
   ], // users will be mentioned based on file glob if no other user was found
   "findPotentialReviewers": true, // mention-bot will try to find potential reviewers based on files history, if disabled, `alwaysNotifyForPaths` is used instead


### PR DESCRIPTION
This provides a new option, `skipTeamPrs`, to the configuration options for `alwaysNotifyForPaths` and `fallbackNotifyForPaths`.

This option works with GitHub teams. The idea is, if you specify that a team should watch a certain path, but then a member of that team modifies one of their own files, then that team does not need to be included in the resulting comment because they already know about it. However, any other teams the PR creator is not a member of should still get notified.

This only applies to `alwaysNotifyForPaths` and `fallbackNotifyForPaths` since a team will never be mentioned by parsing the blame history. Nevertheless, it's hidden behind a config flag to cut down on the number of HTTP requests made in the case where individual users, rather than teams, are watching certain file paths and for the benefit of teams that would prefer they get mentioned in all cases.

