### PR TITLE
Fix Error Message Check for GitHub Enterprise

### DIFF
--- a/server.js
+++ b/server.js
@@ -168,7 +168,7 @@ async function work(body) {
     repoConfig = {...repoConfig, ...configRes};
   } catch (e) {
     if (e.code === 404 &&
-        e.message === '{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}') {
+        e.message.match(/message.*Not Found.*documentation_url.*developer.github.com/)) {
       console.log('Couldn\'t find ' + CONFIG_PATH + ' in repo. Continuing with default configuration.');
     } else {
       console.error(e);


### PR DESCRIPTION
`server.js` checks the existence of the `.mention-bot` config file by comparing the error message strictly with the following string:
```
{"message":"Not Found","documentation_url":"https://developer.github.com/v3"}
````

However, this URL does not work with the enterprise GitHub. For example, the error message we got is:
```
{"message":"Not Found","documentation_url":"https://developer.github.com/enterprise/2.6/v3"}'
```
This pull request takes care of this issue by replacing the `===` with `string#match`.
