### PR TITLE
Fix regex for parseBlame

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -186,7 +186,7 @@ function parseBlame(blame: string): Array<string> {
   // The way the document is structured is that commits and lines are
   // interleaved. So every time we see a commit we grab the author's name
   // and every time we see a line we log the last seen author.
-  var re = /(rel="(?:author|contributor)">([^<]+)<\/a> authored|<tr class="blame-line">)/g;
+  var re = /(<img alt="@([^"]+)" class="avatar blame-commit-avatar"|<td class="blame-commit-info")/g;
 
   var currentAuthor = 'none';
   var lines = [];


### PR DESCRIPTION
Github changed their blame HTML structure so the regex parsing authors needed a rehaul