### PR TITLE
fixed error in getOwnerOrgs

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -438,11 +438,11 @@ async function getTeams(
 }
 
 async function getOwnerOrgs(
-  owner: string,
+  username: string,
   github: Object
 ): Promise<Array<string>> {
   return new Promise(function(resolve, reject) {
-    github.orgs.getForUser({ owner: owner }, function(err, result) {
+    github.orgs.getForUser({ username: username }, function(err, result) {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
I was getting the following error for every pull request opened:

```
2017-01-23T22:23:52.887299+00:00 app[web.1]: { [Error: Empty value for parameter 'username': undefined]
2017-01-23T22:23:52.887309+00:00 app[web.1]:   defaultMessage: 'Bad Request',
2017-01-23T22:23:52.887311+00:00 app[web.1]:   code: '400',
2017-01-23T22:23:52.887309+00:00 app[web.1]:   message: 'Empty value for parameter \'username\': undefined',
2017-01-23T22:23:52.887312+00:00 app[web.1]:   status: 'Bad Request',
2017-01-23T22:23:52.887312+00:00 app[web.1]:   headers: undefined }
2017-01-23T22:23:52.887393+00:00 app[web.1]: undefined
````

Took some time to find out it was in this place... 

Seems like the bug was introduced in #198 