### PR TITLE
Modify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Do you have a GitHub project that is too big for people to subscribe to all the 
 - Go to
  - your project on GitHub > Settings > Webhooks & services > Add Webhook or
  - your organization on GitHub > Settings > Webhooks > Add Webhook
-- Payload URL: (https://mention-bot.herokuapp.com/)
+- Payload URL: (http://<your.domain.name>:5000/)
 - Content type: `application/json`
 - Secret: Leave blank
 - Let me select individual events > Check `Pull Request`


### PR DESCRIPTION
I'm brand-new to mention-bot so please forgive me if I am incorrect. :]

Following the defualt instructions did not work for me. I couldn't find
any instance in which SSL support on the mention-bot end is supported.
I had to disable it in the GitHub hook for mention-bot to work.

I also noted that the default URL for the GitHub webhook needs to be
TCP/5000.