### PR TITLE
Filter requiredOrgs by a method that understands private members

### DIFF
--- a/mention-bot.js
+++ b/mention-bot.js
@@ -492,16 +492,14 @@ async function filterRequiredOrgs(
   config: Object,
   github: Object
 ): Promise<Array<string>> {
-  var promises = owners.map(function(owner) {
-    return getOwnerOrgs(owner, github);
-  });
+  var promises = config.requiredOrgs.map(function(reqOrg) {
+    return getMembersOfOrg(reqOrg, github, 0);
+  })
 
-  var userOrgs = await Promise.all(promises);
-  return owners.filter(function(owner, index) {
-    // user passes if he is in any of the required organizations
-    return config.requiredOrgs.some(function(reqOrg) {
-      return userOrgs[index].indexOf(reqOrg) >= 0;
-    });
+  var currentMembers = [].concat.apply([], await Promise.all(promises));
+  return owners.filter(function(owner) {
+    // User passes if they are in any of the required organizations
+    return currentMembers.indexOf(owner) >= 0;
   });
 }
 


### PR DESCRIPTION
Fixes #209

Javascript is not my strong suite, so this may be wrong. However what I *believe* it will do is use ``getMembersOfOrg`` to fetch a list of every member in every required org then filter the list of owners out by who is contained in that list.

The difference between the new code and the old code is subtle, the old code would iterate over each owner and get a list of organizations that it is a *public* member for. This new code (should) iterate over each organization and get a list of all members that the bot user can see (so public, unless the bot is a member of the org, then public and private).

I believe this should work, though I haven't been able to test it because Github has flagged my bot account for some reason!