### PR TITLE
Allow disabling commenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The bot can be configured by adding a `.mention-bot` file to the base directory 
   "skipAlreadyMentionedPR": false, // mention-bot will ignore if there is already existing an exact mention
   "assignToReviewer": false, // mention-bot assigns the most appropriate reviewer for PR
   "createReviewRequest": false, // mention-bot creates review request for the most appropriate reviewer for PR
+  "createComment": true, // mention-bot creates a comment mentioning the reviewers for the PR
   "skipTitle": "", // mention-bot will ignore PR that includes text in the title,
   "withLabel": "", // mention-bot will only consider PR's with this label. Must set actions to ["labeled"].
   "delayed": false, // mention-bot will wait to comment until specified time in `delayedUntil` value

--- a/server.js
+++ b/server.js
@@ -140,6 +140,7 @@ async function work(body) {
     delayedUntil: '3d',
     assignToReviewer: false,
     createReviewRequest: false,
+    createComment: true,
     skipTitle: '',
     withLabel: '',
     skipCollaboratorPR: false,
@@ -306,6 +307,10 @@ async function work(body) {
   }
 
   function createComment(data, message, reject) {
+    if (!repoConfig.createComment) {
+      return;
+    }
+
     github.issues.createComment({
       owner: data.repository.owner.login, // 'fbsamples'
       repo: data.repository.name, // 'bot-testing'


### PR DESCRIPTION
This is useful if you want to utilize request reviews or issue assignment *instead* of commenting. Currently it's only possible to use them *in addition* to commenting.