### PR TITLE
Add double quotes around PR actions in log

### DIFF
--- a/server.js
+++ b/server.js
@@ -203,7 +203,7 @@ async function work(body) {
   function isValid(repoConfig, data) {
     if (repoConfig.actions.indexOf(data.action) === -1) {
       console.log(
-        'Skipping because action is ' + data.action + '.',
+        'Skipping because action is "' + data.action + '".',
         'We only care about: "' + repoConfig.actions.join("', '") + '"'
       );
       return false;
@@ -211,13 +211,13 @@ async function work(body) {
 
     if (repoConfig.withLabel && data.label &&
         data.label.name != repoConfig.withLabel) {
-      console.log('Skipping because pull request does not have label: ' + repoConfig.withLabel);
+      console.log('Skipping because pull request does not have label: "' + repoConfig.withLabel + '".');
       return false;
     }
 
     if (repoConfig.skipTitle &&
         data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
-      console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle);
+      console.log('Skipping because pull request title contains: "' + repoConfig.skipTitle + '".');
       return false;
     }
 
@@ -254,7 +254,7 @@ async function work(body) {
 
     if (repoConfig.skipTitle &&
         data.pull_request.title.indexOf(repoConfig.skipTitle) > -1) {
-      console.log('Skipping because pull request title contains: ' + repoConfig.skipTitle);
+      console.log('Skipping because pull request title contains: "' + repoConfig.skipTitle + '".');
       return false;
     }
 


### PR DESCRIPTION
This just adds double-quotes and a period for PR actions in console log to match it up with the format of other log lines.