### PR TITLE
Rewriting the parseDiffFile function for simplicity/stability

### DIFF
--- a/__tests__/data/pr229.diff
+++ b/__tests__/data/pr229.diff
@@ -1,0 +1,18 @@
+diff --git a/public/tagging_templates/some_binary.xlsx b/public/tagging_templates/some_binary.xlsx
+new file mode 100644
+index 0000000..d70cdb6
+Binary files /dev/null and b/public/tagging_templates/some_binary.xlsx differ
+diff --git a/public/tagging_templates/other_binary.xlsx b/public/tagging_templates/other_binary.xlsx
+old mode 100755
+new mode 100644
+index 0724fbf..bc2a9c8
+Binary files a/public/tagging_templates/other_binary.xlsx and b/public/tagging_templates/other_binary.xlsx differ
+diff --git a/public/tagging_templates/different_binary.xlsx b/public/tagging_templates/different_binary.xlsx
+old mode 100755
+new mode 100644
+index 019b5ac..938446e
+Binary files a/public/tagging_templates/different_binary.xlsx and b/public/tagging_templates/different_binary.xlsx differ
+diff --git a/spec/fixtures/some_binary.xlsx b/spec/fixtures/some_binary.xlsx
+new file mode 100644
+index 0000000..f8c0a1d
+Binary files /dev/null and b/spec/fixtures/some_binary.xlsx differ

--- a/__tests__/github-mention-test.js
+++ b/__tests__/github-mention-test.js
@@ -400,6 +400,30 @@ describe('Github Mention', function() {
     expect(function() { mentionBot.parseBlame(''); }).not.toThrow();
   });
 
+  it('ParsePR229', function() {
+    var parsed = mentionBot.parseDiff(
+      getFile('pr229.diff')
+    );
+    expect(parsed).toEqual([
+      {
+        path: 'public/tagging_templates/some_binary.xlsx',
+        deletedLines: []
+      },
+      {
+        path: 'public/tagging_templates/other_binary.xlsx',
+        deletedLines: []
+      },
+      {
+        path: 'public/tagging_templates/different_binary.xlsx',
+        deletedLines: []
+      },
+      {
+        path: 'spec/fixtures/some_binary.xlsx',
+        deletedLines: []
+      }
+    ]);
+  });
+
   it('ParseDiff3119', function() {
     var parsed = mentionBot.parseDiff(
       // https://github.com/facebook/react-native/pull/3119.diff


### PR DESCRIPTION
The new function doesn't need to check as many conditions and in our internal use have found this method to be more stable since we were occasionally hitting edge cases where it was hitting unexpected lines.